### PR TITLE
fix: Use authenticated user as author of a comment

### DIFF
--- a/app/Http/Livewire/HasCommentSection.php
+++ b/app/Http/Livewire/HasCommentSection.php
@@ -5,6 +5,7 @@ namespace App\Http\Livewire;
 use App\Models\Comment;
 use App\Models\Document;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 
 trait HasCommentSection
 {
@@ -22,7 +23,9 @@ trait HasCommentSection
         if (blank($this->comment)) {
             return;
         }
-        $result = $this->document?->createComment($this->comment, $this->user->getAuthIdentifier());
+
+        $authorId = intval(Auth::user()->getAuthIdentifier());
+        $result = $this->document?->createComment($this->comment, $authorId);
         if ($result) {
             $this->document->refresh();
             $this->comments = $this->document->comments;

--- a/tests/Feature/Livewire/DocumentUploadTest.php
+++ b/tests/Feature/Livewire/DocumentUploadTest.php
@@ -11,7 +11,7 @@ use App\Models\Passport;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
-use Livewire;
+use Livewire\Livewire;
 use Livewire\WithFileUploads;
 use function Pest\Laravel\actingAs;
 use Storage;
@@ -30,7 +30,7 @@ beforeEach(function () {
     $this->user->documents()->save($this->document);
 
     actingAs($this->user);
-    $this->component = Livewire\Livewire::test('documents-rater', [
+    $this->component = Livewire::test('documents-rater', [
         'user' => $this->user,
         'category' => $this->category,
     ]);
@@ -312,7 +312,7 @@ it('shows comments', function () {
     $this->document->comments()->saveMany($comments);
 
     // Act
-    $component = Livewire\Livewire::test('documents-rater', [
+    $component = Livewire::test('documents-rater', [
         'category' => $this->category,
         'user' => $this->user,
     ]);
@@ -324,4 +324,23 @@ it('shows comments', function () {
                   ->assertSeeText($comment->author->full_name)
                   ->assertSeeText($comment->created_at->translatedFormat('d. F Y H:i'));
     }
+});
+
+test('currently authenticated user is author of comment', function () {
+    // Arrange
+    $attendee = $this->user;
+    $component = Livewire::test('document-upload', [
+        'user' => $attendee,
+        'category' => $this->category->value,
+    ]);
+
+    // Act
+    actingAs($attendee);
+    $component->assertStatus(200)
+              ->set('comment', 'Comment by attendee')
+              ->call('saveComment');
+
+    // Assert
+    expect($this->document->comments[0])
+        ->author_id->toBe($attendee->id);
 });

--- a/tests/Feature/Livewire/DocumentsRaterTest.php
+++ b/tests/Feature/Livewire/DocumentsRaterTest.php
@@ -22,6 +22,7 @@ beforeEach(function () {
                               ->make();
 
     $this->user->documents()->save($this->document);
+    actingAs($this->user);
     $this->component = Livewire::test('documents-rater', [
         'user' => $this->user,
         'category' => $this->category,
@@ -262,4 +263,24 @@ it('shows comments', function () {
                   ->assertSeeText($comment->author->full_name)
                   ->assertSeeText($comment->created_at->translatedFormat('d. F Y H:i'));
     }
+});
+
+test('currently authenticated user is author of comment', function () {
+    // Arrange
+    $attendee = $this->user;
+    $rotex = createUserWithRole('rotex');
+    $component = Livewire::test('documents-rater', [
+        'user' => $attendee,
+        'category' => $this->category,
+    ]);
+
+    // Act
+    actingAs($rotex);
+    $component->assertStatus(200)
+              ->set('comment', 'Comment by Rotex')
+              ->call('saveComment');
+
+    // Assert
+    expect($this->document->comments[0])
+        ->author_id->toBe($rotex->id);
 });


### PR DESCRIPTION
The previous implementation of the DocuemntsRater was wrongly attributing the comments to the user whose documents were being rated.