### PR TITLE
chore(check): Check PR Title and commit message headlines

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -169,7 +169,7 @@ jobs:
         uses: actions/dependency-review-action@v3
 
   deploy-into-sandbox:
-    needs: [ dependency-review, actionlint, phpstan-linter, pint, scan-for-secrets, shellcheck, test ]
+    needs: [ dependency-review, actionlint, phpstan-linter, pint, scan-for-secrets, shellcheck, test, conventional-commits ]
     if: ${{ github.ref_name == 'release-please--branches--main' }}
     uses: ./.github/workflows/deploy.yml
     secrets: inherit

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -128,13 +128,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}
 
-  pr-title:
+  conventional-commits:
     runs-on: ubuntu-latest
     steps:
-      - name: PR Title conforms to Conventional Commits
-        uses: amannn/action-semantic-pull-request@v5
+      - name: At least one conventional commit
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view ${{ github.event.number }} \
+          -R ${{ github.repository }} \
+          --json title,commits --jq '.commits[].messageHeadline, .title' \
+          | grep -E '(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([-a-zA-Z0-9]+\))?.+'
 
   phpstan-linter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Instead of only checking the PR title we'll now check the title and all commit message headlines. At least one of them needs to conform to conventional commits (cc).

The goal is to avoid duplicating messages in the changelog, as the commit might have already be marked as a feature and now the PR title also needs to conform to cc and badaboom badabang, you've got yourself a duplicate.

In addition this allows cc messages to be more precisely placed.